### PR TITLE
Fix echonet payload parse

### DIFF
--- a/custom_components/b_route_meter/adapters/bp35a1.py
+++ b/custom_components/b_route_meter/adapters/bp35a1.py
@@ -249,7 +249,7 @@ class BP35A1Adapter(AdapterInterface):
                     except Exception as e:
                         _LOGGER.debug("Error extracting IPv6 from ERXUDP: %s", e)
 
-                    echonet_payload = tokens[8].rstrip(b"\r\n")
+                    echonet_payload = bytes.fromhex(tokens[8].rstrip(b"\r\n").decode())
                     _LOGGER.debug(
                         "ECHONET payload (%d bytes): %s",
                         len(echonet_payload),

--- a/custom_components/b_route_meter/adapters/bp35a1.py
+++ b/custom_components/b_route_meter/adapters/bp35a1.py
@@ -249,7 +249,7 @@ class BP35A1Adapter(AdapterInterface):
                     except Exception as e:
                         _LOGGER.debug("Error extracting IPv6 from ERXUDP: %s", e)
 
-                    echonet_payload = bytes.fromhex(tokens[8].rstrip(b"\r\n").decode())
+                    echonet_payload = bytes.fromhex(tokens[-1].rstrip(b"\r\n").decode())
                     _LOGGER.debug(
                         "ECHONET payload (%d bytes): %s",
                         len(echonet_payload),

--- a/custom_components/b_route_meter/adapters/bp35c2.py
+++ b/custom_components/b_route_meter/adapters/bp35c2.py
@@ -227,7 +227,7 @@ class BP35C2Adapter(AdapterInterface):
                 if complete_response and b"\r\n" in complete_response:
                     _LOGGER.debug("Complete response: %s", complete_response)
                     tokens = complete_response.split(b" ", 9)
-                    if len(tokens) < 9:
+                    if len(tokens) < 10:
                         _LOGGER.warning(
                             "Incomplete ERXUDP response: %s", complete_response
                         )
@@ -249,7 +249,7 @@ class BP35C2Adapter(AdapterInterface):
                     except Exception as e:
                         _LOGGER.debug("Error extracting IPv6 from ERXUDP: %s", e)
 
-                    echonet_payload = bytes.fromhex(tokens[9].rstrip(b"\r\n").decode())
+                    echonet_payload = bytes.fromhex(tokens[-1].rstrip(b"\r\n").decode())
                     _LOGGER.debug(
                         "ECHONET payload (%d bytes): %s",
                         len(echonet_payload),


### PR DESCRIPTION
Parse the BP35A1 payload in the same way as BP35C2.
This will resolve #7.